### PR TITLE
Autofill "End Date" field

### DIFF
--- a/frontend/src/components/ViewActivities/editActivity.js
+++ b/frontend/src/components/ViewActivities/editActivity.js
@@ -22,7 +22,16 @@ class EditActivity extends React.Component {
   constructor(props){
     super(props);
 
-    this.state = {startTzChanged: false, endTzChanged: false};
+    const activity = props.activity;
+    this.state = {
+      startTzChanged: false, 
+      endTzChanged: false, 
+      startTimeDateChanged: false,
+      endDateFiller: time.getISODate(getField(activity, DB.ACTIVITIES_END_TIME), 
+        getField(activity, DB.ACTIVITIES_END_TZ)),
+      endTimeFiller: time.get24hTime(getField(activity, DB.ACTIVITIES_END_TIME), 
+        getField(activity, DB.ACTIVITIES_END_TZ))
+    };
 
     // Bind state users/modifiers to `this`.
     this.editActivity = this.editActivity.bind(this);
@@ -90,6 +99,13 @@ class EditActivity extends React.Component {
   // selected country's timezones. 
   startTimeTzUpdate = () => { this.setState({startTzChanged : !this.state.startTzChanged})};
   endTimeTzUpdate = () => { this.setState({endTzChanged : !this.state.endTzChanged})};
+
+  startDateUpdate = () => { 
+    this.setState({ 
+      endDateFiller: this.editStartDateRef.current.value, 
+      startTimeDateChanged: !this.state.startTimeDateChanged
+    });
+  }
 
   /**
    * Returns a dropdown of all the timezones.
@@ -200,18 +216,19 @@ class EditActivity extends React.Component {
           this.editStartTimeRef,                           // timeRef, 
           time.get24hTime(getField(activity, DB.ACTIVITIES_START_TIME), 
               getField(activity, DB.ACTIVITIES_START_TZ)), //timeDefault, 
-          this.timezoneDropdown('start', getField(activity, DB.ACTIVITIES_START_TZ)) // tzpicker 
+          this.timezoneDropdown('start', getField(activity, DB.ACTIVITIES_START_TZ)), // tzpicker 
+          this.startDateUpdate, // onChangeDate
           )}
         {formElements.dateTimeTzFormGroup( // END TIME
           'formActivityEndTime',                         // controlId
           'To:',                                         // formLabel
           this.editEndDateRef,                           // dateRef
-          time.getISODate(getField(activity, DB.ACTIVITIES_END_TIME), 
-              getField(activity, DB.ACTIVITIES_END_TZ)), // dateDefault 
+          this.state.endDateFiller, // dateDefault 
           this.editEndTimeRef,                           // timeRef, 
-          time.get24hTime(getField(activity, DB.ACTIVITIES_END_TIME), 
-              getField(activity, DB.ACTIVITIES_END_TZ)), //timeDefault, 
-          this.timezoneDropdown('end', getField(activity, DB.ACTIVITIES_END_TZ)) // tzpicker 
+          this.state.endTimeFiller, //timeDefault, 
+          this.timezoneDropdown('end', getField(activity, DB.ACTIVITIES_END_TZ)), // tzpicker 
+          null, // onChangeDate
+          this.state.startTimeDateChanged // key
           )}
         {formElements.textElementFormGroup( // DESCRIPTION
             'formActivityDescription', // controlId

--- a/frontend/src/components/ViewActivities/editActivityFormElements.js
+++ b/frontend/src/components/ViewActivities/editActivityFormElements.js
@@ -62,15 +62,21 @@ export function locationElementFormGroup(controlId, formLabel, dropdown) {
  * @returns {HTML} A FormGroup for date, time, and timezone.
  */
 export function dateTimeTzFormGroup(controlId, formLabel, dateRef,
-  dateDefault, timeRef, timeDefault, tzpicker) {
+  dateDefault, timeRef, timeDefault, tzpicker, onChangeDate=null, key=null ) {
   return (
-    <Form.Group as={Row} controlId={controlId}>
+  <Form.Group as={Row} controlId={controlId} key={key}>
       <Col sm={TITLEWIDTH}><Form.Label>{formLabel}</Form.Label></Col>
       <Col sm={DATEWIDTH}>
-        <Form.Control type='date' label='date' ref={dateRef} defaultValue={dateDefault}/>
+        <Form.Control 
+          type='date' 
+          label='date' 
+          ref={dateRef} 
+          onChange={onChangeDate} 
+          defaultValue={dateDefault}
+          />
       </Col>
       <Col sm={TIMEWIDTH}>
-        <Form.Control type='time' label='time' ref={timeRef}
+        <Form.Control type='time' label='time' ref={timeRef} 
           defaultValue={timeDefault}/>
       </Col>
       <Col sm={TZPICKERWIDTH}>{tzpicker}</Col>


### PR DESCRIPTION
### What is a quick description of the change?

Autofill the "end date" field on the Activity Editor. 

When the "Start Date" is changed, the "end date" is adjusted to become the same day. In other words, this assumes single-day activities. The end date can be readjusted again if necessary/that assumption is not true.

### Is this fixing an issue?

none

### Are there more details that are relevant?

This PR is one of many created in an effort to reduce the number of button clicks a user makes.

A potential extension would be to make the "end time" field adjust to 1 or 2 hours after the "start time" field in a similar manner. This PR sets up some architecture for this.

### Check lists (check `x` in `[ ]` of list items)

- [  ] Test written/updating
- [  ] Tests passing
- [x] Coding style (indentation, etc)

Please explain why any are not present, if any.
No new functions to test.

### Any additional comments?
Before:
![SLURP (2)](https://user-images.githubusercontent.com/14322650/89452760-c8bedc00-d723-11ea-8781-43275ecde1a7.gif)

After:
![SLURP (1)](https://user-images.githubusercontent.com/14322650/89452570-7da4c900-d723-11ea-8679-fc905e7b5777.gif)
